### PR TITLE
Add coins handled by live

### DIFF
--- a/src/families/algorand/serializer.ts
+++ b/src/families/algorand/serializer.ts
@@ -1,0 +1,42 @@
+import BigNumber from "bignumber.js";
+import { AlgorandTransaction, RawAlgorandTransaction } from "./types";
+
+export const serializeAlgorandTransaction = ({
+  family,
+  mode,
+  fees,
+  assetId,
+  memo,
+  amount,
+  recipient,
+}: AlgorandTransaction): RawAlgorandTransaction => {
+  return {
+    family,
+    amount: amount.toString(),
+    recipient,
+    fees: fees ? fees.toString() : undefined,
+    memo,
+    mode,
+    assetId,
+  };
+};
+
+export const deserializeAlgorandTransaction = ({
+  family,
+  mode,
+  fees,
+  assetId,
+  memo,
+  amount,
+  recipient,
+}: RawAlgorandTransaction): AlgorandTransaction => {
+  return {
+    family,
+    amount: new BigNumber(amount),
+    recipient,
+    fees: fees ? new BigNumber(fees) : undefined,
+    memo,
+    mode,
+    assetId,
+  };
+};

--- a/src/families/algorand/types.ts
+++ b/src/families/algorand/types.ts
@@ -1,0 +1,24 @@
+import type BigNumber from "bignumber.js";
+
+import FAMILIES from "../types";
+
+import type { RawTransactionCommon } from "../../rawTypes";
+import type { TransactionCommon } from "../../types";
+
+export type AlgorandOperationMode = "send" | "optIn" | "claimReward" | "optOut";
+
+export interface AlgorandTransaction extends TransactionCommon {
+  family: FAMILIES.ALGORAND;
+  mode: AlgorandOperationMode;
+  fees?: BigNumber;
+  assetId?: string;
+  memo?: string;
+}
+
+export interface RawAlgorandTransaction extends RawTransactionCommon {
+  family: FAMILIES.ALGORAND;
+  mode: AlgorandOperationMode;
+  fees?: string;
+  assetId?: string;
+  memo?: string;
+}

--- a/src/families/cosmos/serializer.ts
+++ b/src/families/cosmos/serializer.ts
@@ -1,0 +1,42 @@
+import BigNumber from "bignumber.js";
+import type { CosmosTransaction, RawCosmosTransaction } from "./types";
+
+export const serializeCosmosTransaction = ({
+  amount,
+  recipient,
+  family,
+  mode,
+  fees,
+  gas,
+  memo,
+}: CosmosTransaction): RawCosmosTransaction => {
+  return {
+    amount: amount.toString(),
+    recipient,
+    family,
+    mode,
+    fees: fees ? fees.toString() : undefined,
+    gas: gas ? gas.toString() : undefined,
+    memo,
+  };
+};
+
+export const deserializeCosmosTransaction = ({
+  amount,
+  recipient,
+  family,
+  mode,
+  fees,
+  gas,
+  memo,
+}: RawCosmosTransaction): CosmosTransaction => {
+  return {
+    amount: new BigNumber(amount),
+    recipient,
+    family,
+    mode,
+    fees: fees ? new BigNumber(fees) : undefined,
+    gas: gas ? new BigNumber(gas) : undefined,
+    memo,
+  };
+};

--- a/src/families/cosmos/types.ts
+++ b/src/families/cosmos/types.ts
@@ -1,0 +1,30 @@
+import type BigNumber from "bignumber.js";
+
+import FAMILIES from "../types";
+
+import type { RawTransactionCommon } from "../../rawTypes";
+import type { TransactionCommon } from "../../types";
+
+export type CosmosOperationMode =
+  | "send"
+  | "delegate"
+  | "undelegate"
+  | "redelegate"
+  | "claimReward"
+  | "claimRewardCompound";
+
+export interface CosmosTransaction extends TransactionCommon {
+  family: FAMILIES.COSMOS;
+  mode: CosmosOperationMode;
+  fees?: BigNumber;
+  gas?: BigNumber;
+  memo: string;
+}
+
+export interface RawCosmosTransaction extends RawTransactionCommon {
+  family: FAMILIES.COSMOS;
+  mode: CosmosOperationMode;
+  fees?: string;
+  gas?: string;
+  memo: string;
+}

--- a/src/families/crypto_org/serializer.ts
+++ b/src/families/crypto_org/serializer.ts
@@ -1,0 +1,34 @@
+import BigNumber from "bignumber.js";
+import { CryptoOrgTransaction, RawCryptoOrgTransaction } from "./types";
+
+export const serializeCryptoOrgTransaction = ({
+  family,
+  mode,
+  fees,
+  amount,
+  recipient,
+}: CryptoOrgTransaction): RawCryptoOrgTransaction => {
+  return {
+    family,
+    amount: amount.toString(),
+    recipient,
+    fees: fees ? fees.toString() : undefined,
+    mode,
+  };
+};
+
+export const deserializeCryptoOrgTransaction = ({
+  family,
+  mode,
+  fees,
+  amount,
+  recipient,
+}: RawCryptoOrgTransaction): CryptoOrgTransaction => {
+  return {
+    family,
+    amount: new BigNumber(amount),
+    recipient,
+    fees: fees ? new BigNumber(fees) : undefined,
+    mode,
+  };
+};

--- a/src/families/crypto_org/types.ts
+++ b/src/families/crypto_org/types.ts
@@ -1,0 +1,18 @@
+import type BigNumber from "bignumber.js";
+
+import FAMILIES from "../types";
+
+import type { RawTransactionCommon } from "../../rawTypes";
+import type { TransactionCommon } from "../../types";
+
+export interface CryptoOrgTransaction extends TransactionCommon {
+  family: FAMILIES.CRYPTO_ORG;
+  mode: string;
+  fees?: BigNumber;
+}
+
+export interface RawCryptoOrgTransaction extends RawTransactionCommon {
+  family: FAMILIES.CRYPTO_ORG;
+  mode: string;
+  fees?: string;
+}

--- a/src/families/polkadot/serializer.ts
+++ b/src/families/polkadot/serializer.ts
@@ -1,0 +1,38 @@
+import BigNumber from "bignumber.js";
+import type { PolkadotTransaction, RawPolkadotTransaction } from "./types";
+
+export const serializePolkadotTransaction = ({
+  amount,
+  recipient,
+  family,
+  mode,
+  fee,
+  era,
+}: PolkadotTransaction): RawPolkadotTransaction => {
+  return {
+    amount: amount.toString(),
+    recipient,
+    family,
+    mode,
+    fee: fee ? fee.toString() : undefined,
+    era,
+  };
+};
+
+export const deserializePolkadotTransaction = ({
+  amount,
+  recipient,
+  family,
+  mode,
+  fee,
+  era,
+}: RawPolkadotTransaction): PolkadotTransaction => {
+  return {
+    amount: new BigNumber(amount),
+    recipient,
+    family,
+    mode,
+    fee: fee ? new BigNumber(fee) : undefined,
+    era,
+  };
+};

--- a/src/families/polkadot/types.ts
+++ b/src/families/polkadot/types.ts
@@ -1,0 +1,20 @@
+import type BigNumber from "bignumber.js";
+
+import FAMILIES from "../types";
+
+import type { RawTransactionCommon } from "../../rawTypes";
+import type { TransactionCommon } from "../../types";
+
+export interface PolkadotTransaction extends TransactionCommon {
+  family: FAMILIES.POLKADOT;
+  mode: string;
+  fee?: BigNumber;
+  era?: number;
+}
+
+export interface RawPolkadotTransaction extends RawTransactionCommon {
+  family: FAMILIES.POLKADOT;
+  mode: string;
+  fee?: string;
+  era?: number;
+}

--- a/src/families/ripple/serializer.ts
+++ b/src/families/ripple/serializer.ts
@@ -1,0 +1,34 @@
+import BigNumber from "bignumber.js";
+import type { RawRippleTransaction, RippleTransaction } from "./types";
+
+export const serializeRippleTransaction = ({
+  family,
+  fee,
+  tag,
+  amount,
+  recipient,
+}: RippleTransaction): RawRippleTransaction => {
+  return {
+    family,
+    amount: amount.toString(),
+    recipient,
+    fee: fee ? fee.toString() : undefined,
+    tag,
+  };
+};
+
+export const deserializeRippleTransaction = ({
+  family,
+  fee,
+  tag,
+  amount,
+  recipient,
+}: RawRippleTransaction): RippleTransaction => {
+  return {
+    family,
+    amount: new BigNumber(amount),
+    recipient,
+    fee: fee ? new BigNumber(fee) : undefined,
+    tag,
+  };
+};

--- a/src/families/ripple/types.ts
+++ b/src/families/ripple/types.ts
@@ -1,0 +1,18 @@
+import type BigNumber from "bignumber.js";
+
+import FAMILIES from "../types";
+
+import type { RawTransactionCommon } from "../../rawTypes";
+import type { TransactionCommon } from "../../types";
+
+export interface RippleTransaction extends TransactionCommon {
+  family: FAMILIES.RIPPLE;
+  fee?: BigNumber;
+  tag: number;
+}
+
+export interface RawRippleTransaction extends RawTransactionCommon {
+  family: FAMILIES.RIPPLE;
+  fee?: string;
+  tag: number;
+}

--- a/src/families/stellar/serializer.ts
+++ b/src/families/stellar/serializer.ts
@@ -1,0 +1,38 @@
+import BigNumber from "bignumber.js";
+import type { StellarTransaction, RawStellarTransaction } from "./types";
+
+export const serializeStellarTransaction = ({
+  amount,
+  recipient,
+  family,
+  fees,
+  memoType,
+  memoValue,
+}: StellarTransaction): RawStellarTransaction => {
+  return {
+    amount: amount.toString(),
+    recipient,
+    family,
+    fees: fees ? fees.toString() : undefined,
+    memoType,
+    memoValue,
+  };
+};
+
+export const deserializeStellarTransaction = ({
+  amount,
+  recipient,
+  family,
+  fees,
+  memoType,
+  memoValue,
+}: RawStellarTransaction): StellarTransaction => {
+  return {
+    amount: new BigNumber(amount),
+    recipient,
+    family,
+    fees: fees ? new BigNumber(fees) : undefined,
+    memoType,
+    memoValue,
+  };
+};

--- a/src/families/stellar/types.ts
+++ b/src/families/stellar/types.ts
@@ -1,0 +1,20 @@
+import type BigNumber from "bignumber.js";
+
+import FAMILIES from "../types";
+
+import type { RawTransactionCommon } from "../../rawTypes";
+import type { TransactionCommon } from "../../types";
+
+export interface StellarTransaction extends TransactionCommon {
+  family: FAMILIES.STELLAR;
+  fees?: BigNumber;
+  memoType?: string;
+  memoValue?: string;
+}
+
+export interface RawStellarTransaction extends RawTransactionCommon {
+  family: FAMILIES.STELLAR;
+  fees?: string;
+  memoType?: string;
+  memoValue?: string;
+}

--- a/src/families/tezos/serializer.ts
+++ b/src/families/tezos/serializer.ts
@@ -1,0 +1,38 @@
+import BigNumber from "bignumber.js";
+import type { TezosTransaction, RawTezosTransaction } from "./types";
+
+export const serializeTezosTransaction = ({
+  amount,
+  recipient,
+  family,
+  mode,
+  fees,
+  gasLimit,
+}: TezosTransaction): RawTezosTransaction => {
+  return {
+    amount: amount.toString(),
+    recipient,
+    family,
+    mode,
+    fees: fees ? fees.toString() : undefined,
+    gasLimit: gasLimit ? gasLimit.toString() : undefined,
+  };
+};
+
+export const deserializeTezosTransaction = ({
+  amount,
+  recipient,
+  family,
+  mode,
+  fees,
+  gasLimit,
+}: RawTezosTransaction): TezosTransaction => {
+  return {
+    amount: new BigNumber(amount),
+    recipient,
+    family,
+    mode,
+    fees: fees ? new BigNumber(fees) : undefined,
+    gasLimit: gasLimit ? new BigNumber(gasLimit) : undefined,
+  };
+};

--- a/src/families/tezos/types.ts
+++ b/src/families/tezos/types.ts
@@ -1,0 +1,22 @@
+import type BigNumber from "bignumber.js";
+
+import FAMILIES from "../types";
+
+import type { RawTransactionCommon } from "../../rawTypes";
+import type { TransactionCommon } from "../../types";
+
+export type TezosOperationMode = "send" | "delegate" | "undelegate";
+
+export interface TezosTransaction extends TransactionCommon {
+  family: FAMILIES.TEZOS;
+  mode: TezosOperationMode;
+  fees?: BigNumber;
+  gasLimit?: BigNumber;
+}
+
+export interface RawTezosTransaction extends RawTransactionCommon {
+  family: FAMILIES.TEZOS;
+  mode: TezosOperationMode;
+  fees?: string;
+  gasLimit?: string;
+}

--- a/src/families/tron/serializer.ts
+++ b/src/families/tron/serializer.ts
@@ -1,0 +1,38 @@
+import BigNumber from "bignumber.js";
+import type { TronTransaction, RawTronTransaction } from "./types";
+
+export const serializeTronTransaction = ({
+  amount,
+  recipient,
+  family,
+  mode,
+  resource,
+  duration,
+}: TronTransaction): RawTronTransaction => {
+  return {
+    amount: amount.toString(),
+    recipient,
+    family,
+    mode,
+    resource,
+    duration,
+  };
+};
+
+export const deserializeTronTransaction = ({
+  amount,
+  recipient,
+  family,
+  mode,
+  resource,
+  duration,
+}: RawTronTransaction): TronTransaction => {
+  return {
+    amount: new BigNumber(amount),
+    recipient,
+    family,
+    mode,
+    resource,
+    duration,
+  };
+};

--- a/src/families/tron/types.ts
+++ b/src/families/tron/types.ts
@@ -1,0 +1,27 @@
+import FAMILIES from "../types";
+
+import type { RawTransactionCommon } from "../../rawTypes";
+import type { TransactionCommon } from "../../types";
+
+export type TronOperationMode =
+  | "send"
+  | "freeze"
+  | "unfreeze"
+  | "vote"
+  | "claimReward";
+
+export type TronResource = "BANDWIDTH" | "ENERGY";
+
+export interface TronTransaction extends TransactionCommon {
+  family: FAMILIES.TRON;
+  mode: TronOperationMode;
+  resource?: TronResource;
+  duration?: number;
+}
+
+export interface RawTronTransaction extends RawTransactionCommon {
+  family: FAMILIES.TRON;
+  mode: TronOperationMode;
+  resource?: TronResource;
+  duration?: number;
+}

--- a/src/families/types.ts
+++ b/src/families/types.ts
@@ -11,5 +11,6 @@ enum FAMILIES {
   TEZOS = "tezos",
   POLKADOT = "polkadot",
   STELLAR = "stellar",
+  TRON = "tron",
 }
 export default FAMILIES;

--- a/src/families/types.ts
+++ b/src/families/types.ts
@@ -4,5 +4,6 @@
 enum FAMILIES {
   BITCOIN = "bitcoin",
   ETHEREUM = "ethereum",
+  ALGORAND = "algorand",
 }
 export default FAMILIES;

--- a/src/families/types.ts
+++ b/src/families/types.ts
@@ -8,5 +8,6 @@ enum FAMILIES {
   CRYPTO_ORG = "crypto_org",
   RIPPLE = "ripple",
   COSMOS = "cosmos",
+  TEZOS = "tezos",
 }
 export default FAMILIES;

--- a/src/families/types.ts
+++ b/src/families/types.ts
@@ -10,5 +10,6 @@ enum FAMILIES {
   COSMOS = "cosmos",
   TEZOS = "tezos",
   POLKADOT = "polkadot",
+  STELLAR = "stellar",
 }
 export default FAMILIES;

--- a/src/families/types.ts
+++ b/src/families/types.ts
@@ -9,5 +9,6 @@ enum FAMILIES {
   RIPPLE = "ripple",
   COSMOS = "cosmos",
   TEZOS = "tezos",
+  POLKADOT = "polkadot",
 }
 export default FAMILIES;

--- a/src/families/types.ts
+++ b/src/families/types.ts
@@ -6,5 +6,6 @@ enum FAMILIES {
   ETHEREUM = "ethereum",
   ALGORAND = "algorand",
   CRYPTO_ORG = "crypto_org",
+  RIPPLE = "ripple",
 }
 export default FAMILIES;

--- a/src/families/types.ts
+++ b/src/families/types.ts
@@ -7,5 +7,6 @@ enum FAMILIES {
   ALGORAND = "algorand",
   CRYPTO_ORG = "crypto_org",
   RIPPLE = "ripple",
+  COSMOS = "cosmos",
 }
 export default FAMILIES;

--- a/src/families/types.ts
+++ b/src/families/types.ts
@@ -5,5 +5,6 @@ enum FAMILIES {
   BITCOIN = "bitcoin",
   ETHEREUM = "ethereum",
   ALGORAND = "algorand",
+  CRYPTO_ORG = "crypto_org",
 }
 export default FAMILIES;

--- a/src/rawTypes.ts
+++ b/src/rawTypes.ts
@@ -1,5 +1,6 @@
 import type { RawAlgorandTransaction } from "./families/algorand/types";
 import type { RawBitcoinTransaction } from "./families/bitcoin/types";
+import type { RawCosmosTransaction } from "./families/cosmos/types";
 import type { RawCryptoOrgTransaction } from "./families/crypto_org/types";
 import type { RawEthereumTransaction } from "./families/ethereum/types";
 import type { RawRippleTransaction } from "./families/ripple/types";
@@ -26,7 +27,8 @@ export type RawTransaction =
   | RawBitcoinTransaction
   | RawAlgorandTransaction
   | RawCryptoOrgTransaction
-  | RawRippleTransaction;
+  | RawRippleTransaction
+  | RawCosmosTransaction;
 
 export type RawSignedTransaction = {
   operation: unknown;

--- a/src/rawTypes.ts
+++ b/src/rawTypes.ts
@@ -1,5 +1,6 @@
 import type { RawAlgorandTransaction } from "./families/algorand/types";
 import type { RawBitcoinTransaction } from "./families/bitcoin/types";
+import type { RawCryptoOrgTransaction } from "./families/crypto_org/types";
 import type { RawEthereumTransaction } from "./families/ethereum/types";
 
 export type RawAccount = {
@@ -22,7 +23,8 @@ export interface RawTransactionCommon {
 export type RawTransaction =
   | RawEthereumTransaction
   | RawBitcoinTransaction
-  | RawAlgorandTransaction;
+  | RawAlgorandTransaction
+  | RawCryptoOrgTransaction;
 
 export type RawSignedTransaction = {
   operation: unknown;

--- a/src/rawTypes.ts
+++ b/src/rawTypes.ts
@@ -1,3 +1,4 @@
+import type { RawAlgorandTransaction } from "./families/algorand/types";
 import type { RawBitcoinTransaction } from "./families/bitcoin/types";
 import type { RawEthereumTransaction } from "./families/ethereum/types";
 
@@ -18,7 +19,10 @@ export interface RawTransactionCommon {
   recipient: string;
 }
 
-export type RawTransaction = RawEthereumTransaction | RawBitcoinTransaction;
+export type RawTransaction =
+  | RawEthereumTransaction
+  | RawBitcoinTransaction
+  | RawAlgorandTransaction;
 
 export type RawSignedTransaction = {
   operation: unknown;

--- a/src/rawTypes.ts
+++ b/src/rawTypes.ts
@@ -2,6 +2,7 @@ import type { RawAlgorandTransaction } from "./families/algorand/types";
 import type { RawBitcoinTransaction } from "./families/bitcoin/types";
 import type { RawCryptoOrgTransaction } from "./families/crypto_org/types";
 import type { RawEthereumTransaction } from "./families/ethereum/types";
+import type { RawRippleTransaction } from "./families/ripple/types";
 
 export type RawAccount = {
   id: string;
@@ -24,7 +25,8 @@ export type RawTransaction =
   | RawEthereumTransaction
   | RawBitcoinTransaction
   | RawAlgorandTransaction
-  | RawCryptoOrgTransaction;
+  | RawCryptoOrgTransaction
+  | RawRippleTransaction;
 
 export type RawSignedTransaction = {
   operation: unknown;

--- a/src/rawTypes.ts
+++ b/src/rawTypes.ts
@@ -5,6 +5,7 @@ import type { RawCryptoOrgTransaction } from "./families/crypto_org/types";
 import type { RawEthereumTransaction } from "./families/ethereum/types";
 import type { RawPolkadotTransaction } from "./families/polkadot/types";
 import type { RawRippleTransaction } from "./families/ripple/types";
+import type { RawStellarTransaction } from "./families/stellar/types";
 import type { RawTezosTransaction } from "./families/tezos/types";
 
 export type RawAccount = {
@@ -32,7 +33,8 @@ export type RawTransaction =
   | RawRippleTransaction
   | RawCosmosTransaction
   | RawTezosTransaction
-  | RawPolkadotTransaction;
+  | RawPolkadotTransaction
+  | RawStellarTransaction;
 
 export type RawSignedTransaction = {
   operation: unknown;

--- a/src/rawTypes.ts
+++ b/src/rawTypes.ts
@@ -3,6 +3,7 @@ import type { RawBitcoinTransaction } from "./families/bitcoin/types";
 import type { RawCosmosTransaction } from "./families/cosmos/types";
 import type { RawCryptoOrgTransaction } from "./families/crypto_org/types";
 import type { RawEthereumTransaction } from "./families/ethereum/types";
+import type { RawPolkadotTransaction } from "./families/polkadot/types";
 import type { RawRippleTransaction } from "./families/ripple/types";
 import type { RawTezosTransaction } from "./families/tezos/types";
 
@@ -30,7 +31,8 @@ export type RawTransaction =
   | RawCryptoOrgTransaction
   | RawRippleTransaction
   | RawCosmosTransaction
-  | RawTezosTransaction;
+  | RawTezosTransaction
+  | RawPolkadotTransaction;
 
 export type RawSignedTransaction = {
   operation: unknown;

--- a/src/rawTypes.ts
+++ b/src/rawTypes.ts
@@ -7,6 +7,7 @@ import type { RawPolkadotTransaction } from "./families/polkadot/types";
 import type { RawRippleTransaction } from "./families/ripple/types";
 import type { RawStellarTransaction } from "./families/stellar/types";
 import type { RawTezosTransaction } from "./families/tezos/types";
+import type { RawTronTransaction } from "./families/tron/types";
 
 export type RawAccount = {
   id: string;
@@ -34,7 +35,8 @@ export type RawTransaction =
   | RawCosmosTransaction
   | RawTezosTransaction
   | RawPolkadotTransaction
-  | RawStellarTransaction;
+  | RawStellarTransaction
+  | RawTronTransaction;
 
 export type RawSignedTransaction = {
   operation: unknown;

--- a/src/rawTypes.ts
+++ b/src/rawTypes.ts
@@ -4,6 +4,7 @@ import type { RawCosmosTransaction } from "./families/cosmos/types";
 import type { RawCryptoOrgTransaction } from "./families/crypto_org/types";
 import type { RawEthereumTransaction } from "./families/ethereum/types";
 import type { RawRippleTransaction } from "./families/ripple/types";
+import type { RawTezosTransaction } from "./families/tezos/types";
 
 export type RawAccount = {
   id: string;
@@ -28,7 +29,8 @@ export type RawTransaction =
   | RawAlgorandTransaction
   | RawCryptoOrgTransaction
   | RawRippleTransaction
-  | RawCosmosTransaction;
+  | RawCosmosTransaction
+  | RawTezosTransaction;
 
 export type RawSignedTransaction = {
   operation: unknown;

--- a/src/serializers.ts
+++ b/src/serializers.ts
@@ -20,6 +20,10 @@ import {
   serializeEthereumTransaction,
 } from "./families/ethereum/serializer";
 import {
+  deserializePolkadotTransaction,
+  serializePolkadotTransaction,
+} from "./families/polkadot/serializer";
+import {
   deserializeRippleTransaction,
   serializeRippleTransaction,
 } from "./families/ripple/serializer";
@@ -96,6 +100,8 @@ export function serializeTransaction(transaction: Transaction): RawTransaction {
       return serializeCosmosTransaction(transaction);
     case FAMILIES.TEZOS:
       return serializeTezosTransaction(transaction);
+    case FAMILIES.POLKADOT:
+      return serializePolkadotTransaction(transaction);
     default:
       throw new Error("Can't serialize transaction: family not supported");
   }
@@ -119,6 +125,8 @@ export function deserializeTransaction(
       return deserializeCosmosTransaction(rawTransaction);
     case FAMILIES.TEZOS:
       return deserializeTezosTransaction(rawTransaction);
+    case FAMILIES.POLKADOT:
+      return deserializePolkadotTransaction(rawTransaction);
     default:
       throw new Error("Can't deserialize transaction: family not supported");
   }

--- a/src/serializers.ts
+++ b/src/serializers.ts
@@ -8,6 +8,10 @@ import {
   serializeBitcoinTransaction,
 } from "./families/bitcoin/serializer";
 import {
+  deserializeCryptoOrgTransaction,
+  serializeCryptoOrgTransaction,
+} from "./families/crypto_org/serializer";
+import {
   deserializeEthereumTransaction,
   serializeEthereumTransaction,
 } from "./families/ethereum/serializer";
@@ -72,6 +76,8 @@ export function serializeTransaction(transaction: Transaction): RawTransaction {
       return serializeBitcoinTransaction(transaction);
     case FAMILIES.ALGORAND:
       return serializeAlgorandTransaction(transaction);
+    case FAMILIES.CRYPTO_ORG:
+      return serializeCryptoOrgTransaction(transaction);
     default:
       throw new Error("Can't serialize transaction: family not supported");
   }
@@ -87,6 +93,8 @@ export function deserializeTransaction(
       return deserializeBitcoinTransaction(rawTransaction);
     case FAMILIES.ALGORAND:
       return deserializeAlgorandTransaction(rawTransaction);
+    case FAMILIES.CRYPTO_ORG:
+      return deserializeCryptoOrgTransaction(rawTransaction);
     default:
       throw new Error("Can't deserialize transaction: family not supported");
   }

--- a/src/serializers.ts
+++ b/src/serializers.ts
@@ -15,6 +15,10 @@ import {
   deserializeEthereumTransaction,
   serializeEthereumTransaction,
 } from "./families/ethereum/serializer";
+import {
+  deserializeRippleTransaction,
+  serializeRippleTransaction,
+} from "./families/ripple/serializer";
 import FAMILIES from "./families/types";
 
 import type {
@@ -78,6 +82,8 @@ export function serializeTransaction(transaction: Transaction): RawTransaction {
       return serializeAlgorandTransaction(transaction);
     case FAMILIES.CRYPTO_ORG:
       return serializeCryptoOrgTransaction(transaction);
+    case FAMILIES.RIPPLE:
+      return serializeRippleTransaction(transaction);
     default:
       throw new Error("Can't serialize transaction: family not supported");
   }
@@ -95,6 +101,8 @@ export function deserializeTransaction(
       return deserializeAlgorandTransaction(rawTransaction);
     case FAMILIES.CRYPTO_ORG:
       return deserializeCryptoOrgTransaction(rawTransaction);
+    case FAMILIES.RIPPLE:
+      return deserializeRippleTransaction(rawTransaction);
     default:
       throw new Error("Can't deserialize transaction: family not supported");
   }

--- a/src/serializers.ts
+++ b/src/serializers.ts
@@ -23,6 +23,10 @@ import {
   deserializeRippleTransaction,
   serializeRippleTransaction,
 } from "./families/ripple/serializer";
+import {
+  deserializeTezosTransaction,
+  serializeTezosTransaction,
+} from "./families/tezos/serializer";
 import FAMILIES from "./families/types";
 
 import type {
@@ -90,6 +94,8 @@ export function serializeTransaction(transaction: Transaction): RawTransaction {
       return serializeRippleTransaction(transaction);
     case FAMILIES.COSMOS:
       return serializeCosmosTransaction(transaction);
+    case FAMILIES.TEZOS:
+      return serializeTezosTransaction(transaction);
     default:
       throw new Error("Can't serialize transaction: family not supported");
   }
@@ -111,6 +117,8 @@ export function deserializeTransaction(
       return deserializeRippleTransaction(rawTransaction);
     case FAMILIES.COSMOS:
       return deserializeCosmosTransaction(rawTransaction);
+    case FAMILIES.TEZOS:
+      return deserializeTezosTransaction(rawTransaction);
     default:
       throw new Error("Can't deserialize transaction: family not supported");
   }

--- a/src/serializers.ts
+++ b/src/serializers.ts
@@ -35,6 +35,10 @@ import {
   deserializeTezosTransaction,
   serializeTezosTransaction,
 } from "./families/tezos/serializer";
+import {
+  deserializeTronTransaction,
+  serializeTronTransaction,
+} from "./families/tron/serializer";
 import FAMILIES from "./families/types";
 
 import type {
@@ -108,6 +112,8 @@ export function serializeTransaction(transaction: Transaction): RawTransaction {
       return serializePolkadotTransaction(transaction);
     case FAMILIES.STELLAR:
       return serializeStellarTransaction(transaction);
+    case FAMILIES.TRON:
+      return serializeTronTransaction(transaction);
     default:
       throw new Error("Can't serialize transaction: family not supported");
   }
@@ -135,6 +141,8 @@ export function deserializeTransaction(
       return deserializePolkadotTransaction(rawTransaction);
     case FAMILIES.STELLAR:
       return deserializeStellarTransaction(rawTransaction);
+    case FAMILIES.TRON:
+      return deserializeTronTransaction(rawTransaction);
     default:
       throw new Error("Can't deserialize transaction: family not supported");
   }

--- a/src/serializers.ts
+++ b/src/serializers.ts
@@ -28,6 +28,10 @@ import {
   serializeRippleTransaction,
 } from "./families/ripple/serializer";
 import {
+  deserializeStellarTransaction,
+  serializeStellarTransaction,
+} from "./families/stellar/serializer";
+import {
   deserializeTezosTransaction,
   serializeTezosTransaction,
 } from "./families/tezos/serializer";
@@ -102,6 +106,8 @@ export function serializeTransaction(transaction: Transaction): RawTransaction {
       return serializeTezosTransaction(transaction);
     case FAMILIES.POLKADOT:
       return serializePolkadotTransaction(transaction);
+    case FAMILIES.STELLAR:
+      return serializeStellarTransaction(transaction);
     default:
       throw new Error("Can't serialize transaction: family not supported");
   }
@@ -127,6 +133,8 @@ export function deserializeTransaction(
       return deserializeTezosTransaction(rawTransaction);
     case FAMILIES.POLKADOT:
       return deserializePolkadotTransaction(rawTransaction);
+    case FAMILIES.STELLAR:
+      return deserializeStellarTransaction(rawTransaction);
     default:
       throw new Error("Can't deserialize transaction: family not supported");
   }

--- a/src/serializers.ts
+++ b/src/serializers.ts
@@ -1,5 +1,9 @@
 import BigNumber from "bignumber.js";
 import {
+  deserializeAlgorandTransaction,
+  serializeAlgorandTransaction,
+} from "./families/algorand/serializer";
+import {
   deserializeBitcoinTransaction,
   serializeBitcoinTransaction,
 } from "./families/bitcoin/serializer";
@@ -66,6 +70,8 @@ export function serializeTransaction(transaction: Transaction): RawTransaction {
       return serializeEthereumTransaction(transaction);
     case FAMILIES.BITCOIN:
       return serializeBitcoinTransaction(transaction);
+    case FAMILIES.ALGORAND:
+      return serializeAlgorandTransaction(transaction);
     default:
       throw new Error("Can't serialize transaction: family not supported");
   }
@@ -79,6 +85,8 @@ export function deserializeTransaction(
       return deserializeEthereumTransaction(rawTransaction);
     case FAMILIES.BITCOIN:
       return deserializeBitcoinTransaction(rawTransaction);
+    case FAMILIES.ALGORAND:
+      return deserializeAlgorandTransaction(rawTransaction);
     default:
       throw new Error("Can't deserialize transaction: family not supported");
   }

--- a/src/serializers.ts
+++ b/src/serializers.ts
@@ -8,6 +8,10 @@ import {
   serializeBitcoinTransaction,
 } from "./families/bitcoin/serializer";
 import {
+  deserializeCosmosTransaction,
+  serializeCosmosTransaction,
+} from "./families/cosmos/serializer";
+import {
   deserializeCryptoOrgTransaction,
   serializeCryptoOrgTransaction,
 } from "./families/crypto_org/serializer";
@@ -84,6 +88,8 @@ export function serializeTransaction(transaction: Transaction): RawTransaction {
       return serializeCryptoOrgTransaction(transaction);
     case FAMILIES.RIPPLE:
       return serializeRippleTransaction(transaction);
+    case FAMILIES.COSMOS:
+      return serializeCosmosTransaction(transaction);
     default:
       throw new Error("Can't serialize transaction: family not supported");
   }
@@ -103,6 +109,8 @@ export function deserializeTransaction(
       return deserializeCryptoOrgTransaction(rawTransaction);
     case FAMILIES.RIPPLE:
       return deserializeRippleTransaction(rawTransaction);
+    case FAMILIES.COSMOS:
+      return deserializeCosmosTransaction(rawTransaction);
     default:
       throw new Error("Can't deserialize transaction: family not supported");
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type BigNumber from "bignumber.js";
 import type { AlgorandTransaction } from "./families/algorand/types";
 import type { BitcoinTransaction } from "./families/bitcoin/types";
+import type { CryptoOrgTransaction } from "./families/crypto_org/types";
 import type { EthereumTransaction } from "./families/ethereum/types";
 
 export type MessageHandler = (payload: unknown) => Promise<void>;
@@ -85,7 +86,8 @@ export interface TransactionCommon {
 export type Transaction =
   | EthereumTransaction
   | BitcoinTransaction
-  | AlgorandTransaction;
+  | AlgorandTransaction
+  | CryptoOrgTransaction;
 
 export type EstimatedFees = {
   low: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ import type { BitcoinTransaction } from "./families/bitcoin/types";
 import type { CosmosTransaction } from "./families/cosmos/types";
 import type { CryptoOrgTransaction } from "./families/crypto_org/types";
 import type { EthereumTransaction } from "./families/ethereum/types";
+import type { PolkadotTransaction } from "./families/polkadot/types";
 import type { RippleTransaction } from "./families/ripple/types";
 import type { TezosTransaction } from "./families/tezos/types";
 
@@ -93,7 +94,8 @@ export type Transaction =
   | CryptoOrgTransaction
   | RippleTransaction
   | CosmosTransaction
-  | TezosTransaction;
+  | TezosTransaction
+  | PolkadotTransaction;
 
 export type EstimatedFees = {
   low: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ import type { CosmosTransaction } from "./families/cosmos/types";
 import type { CryptoOrgTransaction } from "./families/crypto_org/types";
 import type { EthereumTransaction } from "./families/ethereum/types";
 import type { RippleTransaction } from "./families/ripple/types";
+import type { TezosTransaction } from "./families/tezos/types";
 
 export type MessageHandler = (payload: unknown) => Promise<void>;
 
@@ -91,7 +92,8 @@ export type Transaction =
   | AlgorandTransaction
   | CryptoOrgTransaction
   | RippleTransaction
-  | CosmosTransaction;
+  | CosmosTransaction
+  | TezosTransaction;
 
 export type EstimatedFees = {
   low: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type BigNumber from "bignumber.js";
+import type { AlgorandTransaction } from "./families/algorand/types";
 import type { BitcoinTransaction } from "./families/bitcoin/types";
 import type { EthereumTransaction } from "./families/ethereum/types";
 
@@ -81,7 +82,10 @@ export interface TransactionCommon {
   recipient: string;
 }
 
-export type Transaction = EthereumTransaction | BitcoinTransaction;
+export type Transaction =
+  | EthereumTransaction
+  | BitcoinTransaction
+  | AlgorandTransaction;
 
 export type EstimatedFees = {
   low: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import type { AlgorandTransaction } from "./families/algorand/types";
 import type { BitcoinTransaction } from "./families/bitcoin/types";
 import type { CryptoOrgTransaction } from "./families/crypto_org/types";
 import type { EthereumTransaction } from "./families/ethereum/types";
+import type { RippleTransaction } from "./families/ripple/types";
 
 export type MessageHandler = (payload: unknown) => Promise<void>;
 
@@ -87,7 +88,8 @@ export type Transaction =
   | EthereumTransaction
   | BitcoinTransaction
   | AlgorandTransaction
-  | CryptoOrgTransaction;
+  | CryptoOrgTransaction
+  | RippleTransaction;
 
 export type EstimatedFees = {
   low: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type BigNumber from "bignumber.js";
 import type { AlgorandTransaction } from "./families/algorand/types";
 import type { BitcoinTransaction } from "./families/bitcoin/types";
+import type { CosmosTransaction } from "./families/cosmos/types";
 import type { CryptoOrgTransaction } from "./families/crypto_org/types";
 import type { EthereumTransaction } from "./families/ethereum/types";
 import type { RippleTransaction } from "./families/ripple/types";
@@ -89,7 +90,8 @@ export type Transaction =
   | BitcoinTransaction
   | AlgorandTransaction
   | CryptoOrgTransaction
-  | RippleTransaction;
+  | RippleTransaction
+  | CosmosTransaction;
 
 export type EstimatedFees = {
   low: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ import type { CryptoOrgTransaction } from "./families/crypto_org/types";
 import type { EthereumTransaction } from "./families/ethereum/types";
 import type { PolkadotTransaction } from "./families/polkadot/types";
 import type { RippleTransaction } from "./families/ripple/types";
+import type { StellarTransaction } from "./families/stellar/types";
 import type { TezosTransaction } from "./families/tezos/types";
 
 export type MessageHandler = (payload: unknown) => Promise<void>;
@@ -95,7 +96,8 @@ export type Transaction =
   | RippleTransaction
   | CosmosTransaction
   | TezosTransaction
-  | PolkadotTransaction;
+  | PolkadotTransaction
+  | StellarTransaction;
 
 export type EstimatedFees = {
   low: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ import type { PolkadotTransaction } from "./families/polkadot/types";
 import type { RippleTransaction } from "./families/ripple/types";
 import type { StellarTransaction } from "./families/stellar/types";
 import type { TezosTransaction } from "./families/tezos/types";
+import type { TronTransaction } from "./families/tron/types";
 
 export type MessageHandler = (payload: unknown) => Promise<void>;
 
@@ -97,7 +98,8 @@ export type Transaction =
   | CosmosTransaction
   | TezosTransaction
   | PolkadotTransaction
-  | StellarTransaction;
+  | StellarTransaction
+  | TronTransaction;
 
 export type EstimatedFees = {
   low: number;


### PR DESCRIPTION
Add transaction types, serialisers and deserialisers for each main coin family handled in ledger-live-common, alongside existing BTC and ETH ones.

## Context

https://ledgerhq.atlassian.net/browse/LL-6364
https://ledgerhq.atlassian.net/browse/LL-6373
https://ledgerhq.atlassian.net/browse/LL-6374
