### PR TITLE
Remove test from build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,5 +32,5 @@
     /* Disallow inconsistently-cased references to the same file. */
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/**/*", "tests/**/*"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
We don't want tests included in build folder (or at least not like that) since it breaks published file archi

What we want:

```
dist
├── LedgerLivePlatformSDK
├── deviceBridge.d.ts
├── deviceBridge.js
├── families
├── index.d.ts
├── index.js
├── logger.d.ts
├── logger.js
├── mock
├── rawTypes.d.ts
├── rawTypes.js
├── serializers.d.ts
├── serializers.js
├── transports
├── types.d.ts
└── types.js
```

Here we can directly access source from root of dep such as `import { XXX } from "ledger-live-platform-sdk";`


What we get when we add `tests` folder to dist:

```
dist
├── src
└── tests
```

Here we must do some digging in the dep and import like so  `import { XXX } from "ledger-live-platform-sdk/dist/src";`